### PR TITLE
Updated THAA quantification to include dilution

### DIFF
--- a/Control.Rmd
+++ b/Control.Rmd
@@ -318,7 +318,7 @@ GBT_StdCurves_BlksSub <- GBT_StdCurves %>%
                                  substr(Replicate.Name, 1, nchar(Replicate.Name)-2), Replicate.Name)) %>%
   group_by(Precursor.Ion.Name, runtype) %>%
   mutate(Area = ifelse(str_detect(Replicate.Name, "Blk"), 
-                       round(mean(Area, na.rm = TRUE)), Area)) %>%
+                       round(max(Area, na.rm = TRUE)), Area)) %>%
   unique() %>%
   ungroup() %>%
   group_by(Precursor.Ion.Name) %>%
@@ -380,7 +380,7 @@ Final.Concentrations <- read.csv("data_raw/GBT-Fate_THAA_T0-Tlong.csv") %>%
                                  substr(Replicate.Name, 1, nchar(Replicate.Name)-2), Replicate.Name)) %>%
   group_by(Precursor.Ion.Name, runtype) %>%
   mutate(Area = ifelse(str_detect(Replicate.Name, "Blk"), 
-                       round(mean(Area, na.rm = TRUE)), Area)) %>%
+                       round(max(Area, na.rm = TRUE)), Area)) %>%
   unique() %>%
   ungroup() %>%
   group_by(Precursor.Ion.Name) %>%

--- a/Control.Rmd
+++ b/Control.Rmd
@@ -403,7 +403,10 @@ Final.Concentrations.SlopeCalc <- Final.Concentrations %>%
          # (x2 - x1) = (y2 - y1) / slope
          NewConc = (Area_noBlank - Zero.Concentration.Area)/(Slope),
          Conc.Diff = abs(NewConc - Calculated.Concentration),
-         RealCon = Area_noBlank/Slope)
+         RealCon = Area_noBlank/Slope,
+         Concenctration.uM.with.Dilution.Correction = RealCon*10) ## with taking the dilution into account: we took a 10 uL aliquot of the hydrolyzed amino acid sample and diluted to 100 uL total when we added the reagents for derivitization, so the 'original' concentration is 10 x what we calucated here.
+
+
 ```
 
 ```{r, Save files}


### PR DESCRIPTION
Apparently when we derivatize the amino acids there is a 10 fold dilution of the original sample. this means that the values we calculated were 10 times too small. I made a new column that corrects for this dilution.